### PR TITLE
Don't hide emoji-picker.desktop from AppStream

### DIFF
--- a/engine/emoji-picker.desktop.in.in
+++ b/engine/emoji-picker.desktop.in.in
@@ -7,4 +7,3 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=GTK;Utility;
-X-AppStream-Ignore=true


### PR DESCRIPTION
Correction of commit 964f03d3

That part was faulty thinking on my side. In the \<launchable/> tag
emoji-picker.appdata.xml refers to emoji-picker.desktop, so the latter
must not be hidden.