### PR TITLE
Ensure enum.Flag's obj._value_ is an integer

### DIFF
--- a/engine/itb_util.py
+++ b/engine/itb_util.py
@@ -3123,7 +3123,7 @@ class InputPurpose(Enum):
     def __new__(cls, attr) -> Any:
         obj = object.__new__(cls)
         if hasattr(Gtk, 'InputPurpose') and hasattr(Gtk.InputPurpose, attr):
-            obj._value_ = getattr(Gtk.InputPurpose, attr)
+            obj._value_ = int(getattr(Gtk.InputPurpose, attr))
         else:
             obj._value_ = -1
         return obj
@@ -3242,7 +3242,7 @@ class InputHints(Flag):
     def __new__(cls, attr: str) -> Any:
         obj = object.__new__(cls)
         if hasattr(Gtk, 'InputHints') and hasattr(Gtk.InputHints, attr):
-            obj._value_ = getattr(Gtk.InputHints, attr)
+            obj._value_ = int(getattr(Gtk.InputHints, attr))
         else:
             obj._value_ = 0
         return obj


### PR DESCRIPTION
In Python 3.10 a new check was added that fails when obj._value_ is not integer
but another enum.Flag's member:

    Traceback (most recent call last):
      File "/usr/share/ibus-typing-booster/engine/emoji_picker.py", line 42, in <module>
        import itb_util
      File "/usr/share/ibus-typing-booster/engine/itb_util.py", line 3191, in <module>
        class InputHints(Flag):
      File "/usr/lib64/python3.10/enum.py", line 484, in __new__
        raise exc
      File "/usr/lib64/python3.10/enum.py", line 246, in __set_name__
        and _is_single_bit(value)
      File "/usr/lib64/python3.10/enum.py", line 73, in _is_single_bit
        num &= num - 1
    TypeError: unsupported operand type(s) for &=: 'InputHints' and 'NoneType'

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1970626