### PR TITLE
drop python<=3.7 support

### DIFF
--- a/engine/emoji_picker.py
+++ b/engine/emoji_picker.py
@@ -248,11 +248,11 @@ class EmojiPickerUI(Gtk.Window): # type: ignore
             itb_util.xdg_save_data_path('emoji-picker'),
             'options')
         self._read_options()
-        if not font is None:
+        if font is not None:
             self._font = font
-        if not fontsize is None:
+        if fontsize is not None:
             self._fontsize = fontsize
-        if not fallback is None:
+        if fallback is not None:
             self._fallback = bool(fallback)
         self._save_options()
         self.connect('destroy-event', self.on_destroy_event)
@@ -260,10 +260,10 @@ class EmojiPickerUI(Gtk.Window): # type: ignore
         self.connect('key-press-event', self.on_main_window_key_press_event)
         self._languages = languages
         self._emoji_unicode_min = '0.0'
-        if not emoji_unicode_min is None:
+        if emoji_unicode_min is not None:
             self._emoji_unicode_min = emoji_unicode_min
         self._emoji_unicode_max = '100.0'
-        if not emoji_unicode_max is None:
+        if emoji_unicode_max is not None:
             self._emoji_unicode_max = emoji_unicode_max
 
         self._unicode_data_all = unicode_data_all
@@ -599,7 +599,7 @@ class EmojiPickerUI(Gtk.Window): # type: ignore
             label_key_display: str,
             language: str,
             language_iter: Any) -> bool:
-        if not label_key in self._emoji_by_label[language]:
+        if label_key not in self._emoji_by_label[language]:
             return False
         labels = self._sort_labels(
             self._emoji_by_label[language][label_key],

--- a/engine/emoji_picker.py
+++ b/engine/emoji_picker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus
@@ -888,7 +887,6 @@ class EmojiPickerUI(Gtk.Window): # type: ignore
         if os.path.isfile(self._options_file):
             try:
                 with open(self._options_file,
-                          mode='r',
                           encoding='UTF-8') as options_file:
                     options_dict = ast.literal_eval(options_file.read())
             except (PermissionError, SyntaxError, IndentationError) as error:
@@ -954,7 +952,6 @@ class EmojiPickerUI(Gtk.Window): # type: ignore
         if os.path.isfile(self._recently_used_emoji_file):
             try:
                 with open(self._recently_used_emoji_file,
-                          mode='r',
                           encoding='UTF-8') as recently_used_file:
                     recently_used_emoji = ast.literal_eval(
                         recently_used_file.read())

--- a/engine/factory.py
+++ b/engine/factory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sw=4 sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/engine/hunspell_suggest.py
+++ b/engine/hunspell_suggest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/engine/hunspell_table.py
+++ b/engine/hunspell_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus
@@ -1153,8 +1152,8 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
                 stripped_transliterated_string = (
                     itb_util.lstrip_token(self._transliterated_strings[ime]))
                 if (stripped_transliterated_string
-                        and ((len(stripped_transliterated_string)
-                              >= self._min_char_complete))):
+                        and (len(stripped_transliterated_string)
+                              >= self._min_char_complete)):
                     self.is_lookup_table_enabled_by_min_char_complete = True
                 if (self.is_lookup_table_enabled_by_min_char_complete
                         or self.is_lookup_table_enabled_by_tab):
@@ -1862,12 +1861,12 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
         for prop in sub_properties:
             if sub_properties[prop]['number'] == int(current_mode):
                 symbol = sub_properties[prop]['symbol']
-                label = '%(label)s (%(symbol)s)' % {
-                    'label': menu['label'],
-                    'symbol': symbol}
-                tooltip = '%(tooltip)s\n%(shortcut_hint)s' % {
-                    'tooltip': menu['tooltip'],
-                    'shortcut_hint': menu['shortcut_hint']}
+                label = '{label} ({symbol})'.format(
+                    label=menu['label'],
+                    symbol=symbol)
+                tooltip = '{tooltip}\n{shortcut_hint}'.format(
+                    tooltip=menu['tooltip'],
+                    shortcut_hint=menu['shortcut_hint'])
         visible = len(self.get_dictionary_names()) > 1
         self._init_or_update_sub_properties_dictionary(
             sub_properties, current_mode=current_mode)
@@ -1908,12 +1907,12 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
         for prop in sub_properties:
             if sub_properties[prop]['number'] == int(current_mode):
                 symbol = sub_properties[prop]['symbol']
-                label = '%(label)s (%(symbol)s)' % {
-                    'label': menu['label'],
-                    'symbol': symbol}
-                tooltip = '%(tooltip)s\n%(shortcut_hint)s' % {
-                    'tooltip': menu['tooltip'],
-                    'shortcut_hint': menu['shortcut_hint']}
+                label = '{label} ({symbol})'.format(
+                    label=menu['label'],
+                    symbol=symbol)
+                tooltip = '{tooltip}\n{shortcut_hint}'.format(
+                    tooltip=menu['tooltip'],
+                    shortcut_hint=menu['shortcut_hint'])
         visible = len(self.get_current_imes()) > 1
         self._init_or_update_sub_properties_preedit_ime(
             sub_properties, current_mode=current_mode)
@@ -3146,9 +3145,9 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
             self._input_purpose in [itb_util.InputPurpose.TERMINAL.value]):
             return ''
         language_code = '*'
-        used_french_spacing_dictionaries = set(
-            ('fr_FR', 'fr_MC', 'fr_BE', 'fr_LU', 'fr_CH', 'fr_CA')
-        ).intersection(self._dictionary_names)
+        used_french_spacing_dictionaries = {
+            'fr_FR', 'fr_MC', 'fr_BE', 'fr_LU', 'fr_CH', 'fr_CA'
+        }.intersection(self._dictionary_names)
         if used_french_spacing_dictionaries:
             if self._dictionary_names[0] in used_french_spacing_dictionaries:
                 language_code =  self._dictionary_names[0]

--- a/engine/hunspell_table.py
+++ b/engine/hunspell_table.py
@@ -1870,7 +1870,7 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
         visible = len(self.get_dictionary_names()) > 1
         self._init_or_update_sub_properties_dictionary(
             sub_properties, current_mode=current_mode)
-        if not key in self._prop_dict: # initialize property
+        if key not in self._prop_dict: # initialize property
             self._prop_dict[key] = IBus.Property(
                 key=key,
                 prop_type=IBus.PropType.MENU,
@@ -1916,7 +1916,7 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
         visible = len(self.get_current_imes()) > 1
         self._init_or_update_sub_properties_preedit_ime(
             sub_properties, current_mode=current_mode)
-        if not key in self._prop_dict: # initialize property
+        if key not in self._prop_dict: # initialize property
             self._prop_dict[key] = IBus.Property(
                 key=key,
                 prop_type=IBus.PropType.MENU,
@@ -2052,7 +2052,7 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
                        or self._keybindings['toggle_input_mode_on_off'])
         self._init_or_update_sub_properties(
             menu_key, sub_properties_dict, current_mode=current_mode)
-        if not menu_key in self._prop_dict: # initialize property
+        if menu_key not in self._prop_dict: # initialize property
             self._prop_dict[menu_key] = IBus.Property(
                 key=menu_key,
                 prop_type=IBus.PropType.MENU,
@@ -2084,7 +2084,7 @@ class TypingBoosterEngine(IBus.Engine): # type: ignore
         '''
         Initialize or update the sub-properties of a property menu entry.
         '''
-        if not menu_key in self._sub_props_dict:
+        if menu_key not in self._sub_props_dict:
             update = False
             self._sub_props_dict[menu_key] = IBus.PropList()
         else:

--- a/engine/itb_active_window.py
+++ b/engine/itb_active_window.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/engine/itb_emoji.py
+++ b/engine/itb_emoji.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus
@@ -684,8 +683,8 @@ class EmojiMatcher():
                 line = re.sub(r'#.*$', '', line).strip()
                 if not line:
                     continue
-                codepoint_string, property_string = [
-                    x.strip() for x in line.split(';')[:2]]
+                codepoint_string, property_string = (
+                    x.strip() for x in line.split(';')[:2])
                 codepoint_range = [
                     int(x, 16) for x in codepoint_string.split('..')]
                 if len(codepoint_range) == 1:
@@ -732,8 +731,8 @@ class EmojiMatcher():
                 line = re.sub(r'#.*$', '', line).strip()
                 if not line:
                     continue
-                codepoints, property_string, name = [
-                    x.strip() for x in line.split(';')[:3]]
+                codepoints, property_string, name = (
+                    x.strip() for x in line.split(';')[:3])
                 if property_string == 'Basic_Emoji':
                     continue
                 if codepoints == '0023 FE0F 20E3' and name == 'keycap:':
@@ -782,8 +781,8 @@ class EmojiMatcher():
                 line = re.sub(r'#.*$', '', line).strip()
                 if not line:
                     continue
-                codepoints, property_string, name = [
-                    x.strip() for x in line.split(';')[:3]]
+                codepoints, property_string, name = (
+                    x.strip() for x in line.split(';')[:3])
                 emoji_string = ''
                 for codepoint in codepoints.split(' '):
                     emoji_string += chr(int(codepoint, 16))
@@ -871,8 +870,8 @@ class EmojiMatcher():
                 line = re.sub(r'#.*$', '', line).strip()
                 if not line:
                     continue
-                codepoints, property_string = [
-                    x.strip() for x in line.split(';')[:2]]
+                codepoints, property_string = (
+                    x.strip() for x in line.split(';')[:2])
                 if property_string != 'fully-qualified':
                     # The non-fully-qualified sequences are
                     # all duplicates of the fully-qualified

--- a/engine/itb_emoji.py
+++ b/engine/itb_emoji.py
@@ -1963,16 +1963,15 @@ class EmojiMatcher():
                         # the categories in emoji-picker:
                         continue
                 language = emoji_key[1]
-                if not language in emoji_by_label_dict:
+                if language not in emoji_by_label_dict:
                     emoji_by_label_dict[language] = {}
                 if label_key in emoji_value:
-                    if not label_key in emoji_by_label_dict[language]:
+                    if label_key not in emoji_by_label_dict[language]:
                         emoji_by_label_dict[language][label_key] = {}
                     if label_key == 'ucategories':
                         ucategory_label_full = ', '.join(
                             emoji_value[label_key])
-                        if (not ucategory_label_full
-                                in emoji_by_label_dict[language][label_key]):
+                        if (ucategory_label_full not in emoji_by_label_dict[language][label_key]):
                             emoji_by_label_dict[
                                 language][
                                     label_key][
@@ -1984,8 +1983,7 @@ class EmojiMatcher():
                                         ucategory_label_full].append(emoji)
                     else:
                         for label in emoji_value[label_key]:
-                            if (not label in
-                                    emoji_by_label_dict[language][label_key]):
+                            if (label not in emoji_by_label_dict[language][label_key]):
                                 emoji_by_label_dict[
                                     language][
                                         label_key][

--- a/engine/itb_nltk.py
+++ b/engine/itb_nltk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus
@@ -54,9 +53,9 @@ def synonyms(word: str, keep_original: bool = True) -> List[str]:
     >>> synonyms('fedora', keep_original = False)
     ['Stetson', 'felt hat', 'homburg', 'trilby']
     '''
-    result = sorted(set(lemma_name.replace('_', ' ')
+    result = sorted({lemma_name.replace('_', ' ')
                         for synset in nltk.corpus.wordnet.synsets(word)
-                        for lemma_name in synset.lemma_names()))
+                        for lemma_name in synset.lemma_names()})
     if word in result:
         result.remove(word)
     if keep_original:
@@ -82,10 +81,10 @@ def hyponyms(word: str, keep_original: bool = True) -> List[str]:
     ['Panama', 'Panama hat', 'Stetson', 'bearskin', 'beaver', 'boater', 'bonnet', 'bowler', 'bowler hat', 'busby', 'campaign hat', 'cavalier hat', 'cocked hat', 'cowboy hat', 'deerstalker', 'derby', 'derby hat', 'dress hat', 'dunce cap', "dunce's cap", 'fedora', 'felt hat', "fool's cap", 'fur hat', 'high hat', 'homburg', 'leghorn', 'millinery', 'opera hat', 'plug hat', 'poke bonnet', 'sailor', 'shako', 'shovel hat', 'silk hat', 'skimmer', 'slouch hat', 'snap-brim hat', 'sombrero', "sou'wester", 'stovepipe', 'straw hat', 'sun hat', 'sunhat', 'ten-gallon hat', 'tirolean', 'titfer', 'top hat', 'topper', 'toque', 'trilby', 'tyrolean', "woman's hat"]
     '''
     # pylint: enable=line-too-long
-    result = sorted(set(lemma.name().replace('_', ' ')
+    result = sorted({lemma.name().replace('_', ' ')
                         for synset in nltk.corpus.wordnet.synsets(word)
                         for hyponym in synset.hyponyms()
-                        for lemma in hyponym.lemmas()))
+                        for lemma in hyponym.lemmas()})
     if word in result:
         result.remove(word)
     if keep_original:
@@ -109,10 +108,10 @@ def hypernyms(word: str, keep_original: bool = True) -> List[str]:
     >>> hypernyms('fedora', keep_original = False)
     ['chapeau', 'hat', 'lid']
     '''
-    result = sorted(set(lemma.name().replace('_', ' ')
+    result = sorted({lemma.name().replace('_', ' ')
                         for synset in nltk.corpus.wordnet.synsets(word)
                         for hypernym in synset.hypernyms()
-                        for lemma in hypernym.lemmas()))
+                        for lemma in hypernym.lemmas()})
     if word in result:
         result.remove(word)
     if keep_original:

--- a/engine/itb_pango.py
+++ b/engine/itb_pango.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/engine/itb_sound.py
+++ b/engine/itb_sound.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/engine/itb_util.py
+++ b/engine/itb_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus
@@ -31,10 +30,7 @@ from typing import Union
 from typing import Iterable
 from typing import Callable
 import sys
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 from enum import Enum, Flag
 import os
 import re
@@ -2986,7 +2982,7 @@ def color_string_to_argb(color_string: str) -> int:
     return (((int(gdk_rgba.alpha * 0xff) & 0xff) << 24)
             + ((int(gdk_rgba.red * 0xff) & 0xff) << 16)
             + ((int(gdk_rgba.green * 0xff) & 0xff) << 8)
-            + ((int(gdk_rgba.blue * 0xff) & 0xff)))
+            + (int(gdk_rgba.blue * 0xff) & 0xff))
 
 def is_ascii(text: str) -> bool:
     '''Checks whether all characters in text are ASCII characters
@@ -3383,7 +3379,6 @@ def get_hunspell_dictionary_wordlist(
         aff_buffer = ''
         try:
             with open(aff_path,
-                      mode='r',
                       encoding='ISO-8859-1',
                       errors='ignore') as aff_file:
                 aff_buffer = aff_file.read().replace('\r\n', '\n')
@@ -4267,7 +4262,6 @@ class ComposeSequences:
             return
         try:
             with open(compose_path,
-                      mode='r',
                       encoding='UTF-8',
                       errors='ignore') as compose_file:
                 lines = compose_file.readlines()
@@ -4995,7 +4989,6 @@ class M17nDbInfo:
             for mim_path in glob.glob(os.path.join(dirname, '*.mim')):
                 try:
                     with open(mim_path,
-                              mode='r',
                               encoding='UTF-8',
                               errors='ignore') as ime_file:
                         full_contents = ime_file.read()

--- a/engine/itb_util.py
+++ b/engine/itb_util.py
@@ -4207,7 +4207,7 @@ class ComposeSequences:
         compose_sequences = self._compose_sequences
         if result == '':
             for keyval in keyvals:
-                if not keyval in compose_sequences:
+                if keyval not in compose_sequences:
                     return
                 if (isinstance(compose_sequences[keyval], str)
                     or len(compose_sequences[keyval]) == 1):
@@ -4216,7 +4216,7 @@ class ComposeSequences:
                 compose_sequences = compose_sequences[keyval]
             return
         for keyval in keyvals:
-            if (not keyval in compose_sequences
+            if (keyval not in compose_sequences
                 or isinstance(compose_sequences[keyval], str)):
                 compose_sequences[keyval] = {}
             last_compose_sequences = compose_sequences
@@ -4470,7 +4470,7 @@ class ComposeSequences:
                     return '' # Invalid dead key sequence
                 character = IBus.keyval_to_unicode(keyval)
                 if (not character
-                    or not unicodedata.category(character) in ('Lu', 'Ll')):
+                    or unicodedata.category(character) not in ('Lu', 'Ll')):
                     return '' # Invalid dead key sequence
                 combining_sequence = character + combining_sequence
         return unicodedata.normalize('NFC', combining_sequence)

--- a/engine/m17n_translit.py
+++ b/engine/m17n_translit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus
@@ -1107,7 +1106,7 @@ class Transliterator:
         # contents.  But apparently that final 'nil' is necessary to
         # make it work reliably. We can do this here because above we
         # read the preedit already and don’t need it anymore.
-        _symbol = libm17n__msymbol('nil'.encode('utf-8')) # type: ignore
+        _symbol = libm17n__msymbol(b'nil') # type: ignore
         _retval = libm17n__minput_filter( # type: ignore
             self._ic, _symbol, ctypes.c_void_p(None))
         if not ascii_digits:
@@ -1154,7 +1153,7 @@ class Transliterator:
         plist = libm17n__minput_get_variable( # type: ignore
             libm17n__msymbol(self._language.encode('utf-8')), # type: ignore
             libm17n__msymbol(self._name.encode('utf-8')), # type: ignore
-            libm17n__msymbol('nil'.encode('utf-8'))) # type: ignore
+            libm17n__msymbol(b'nil')) # type: ignore
         while bool(plist): # NULL pointers have a False boolean value
             key = libm17n__mplist_key(plist) # type: ignore
             if not bool(key): # NULL pointers have a False boolean value
@@ -1273,7 +1272,7 @@ class Transliterator:
                 if key_name == b'symbol':
                     libm17n__mplist_add( # type: ignore
                         new_value_plist,
-                        libm17n__msymbol('symbol'.encode('utf-8')), # type: ignore
+                        libm17n__msymbol(b'symbol'), # type: ignore
                         libm17n__msymbol(variable_value.encode('utf-8'))) # type: ignore
                 elif key_name == b'mtext':
                     mtext = libm17n__mconv_decode_buffer( # type: ignore
@@ -1282,14 +1281,14 @@ class Transliterator:
                         len(variable_value.encode('utf-8')))
                     libm17n__mplist_add( # type: ignore
                         new_value_plist,
-                        libm17n__msymbol('mtext'.encode('utf-8')), # type: ignore
+                        libm17n__msymbol(b'mtext'), # type: ignore
                         mtext)
                 elif key_name == b'integer':
                     try:
                         int_value = int(variable_value, 10)
                         libm17n__mplist_add( # type: ignore
                             new_value_plist,
-                            libm17n__msymbol('integer'.encode('utf-8')), # type: ignore
+                            libm17n__msymbol(b'integer'), # type: ignore
                             int_value)
                     except ValueError:
                         new_value_plist = libm17n__mplist() # type: ignore

--- a/engine/main.py
+++ b/engine/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/engine/tabsqlitedb.py
+++ b/engine/tabsqlitedb.py
@@ -531,7 +531,7 @@ class TabSqliteDb:
         p_phrase = itb_util.remove_accents(p_phrase.lower())
         pp_phrase = itb_util.remove_accents(pp_phrase.lower())
         title_case = input_phrase.istitle()
-        if not ' ' in input_phrase:
+        if ' ' not in input_phrase:
             # Get suggestions from hunspell dictionaries. But only
             # if input_phrase does not contain spaces. The hunspell
             # dictionaries contain only single words, not sentences.

--- a/engine/tabsqlitedb.py
+++ b/engine/tabsqlitedb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/engine/tabstatistics.py
+++ b/engine/tabstatistics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/setup/i18n.py
+++ b/setup/i18n.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/setup/main.py
+++ b/setup/main.py
@@ -2458,7 +2458,7 @@ class SetupUI(Gtk.Window): # type: ignore
         # add some spaces for nicer formatting:
         row += ' ' * (20 - len(ime))
         title = ''
-        if not M17N_DB_INFO is None:
+        if M17N_DB_INFO is not None:
             title = M17N_DB_INFO.get_title(ime)
         if title:
             row += '\t' + '(' + title + ')'
@@ -3966,7 +3966,7 @@ class SetupUI(Gtk.Window): # type: ignore
         label.set_margin_end(margin)
         label.set_margin_top(margin)
         label.set_margin_bottom(margin)
-        if not M17N_DB_INFO is None:
+        if M17N_DB_INFO is not None:
             image = Gtk.Image.new_from_file(M17N_DB_INFO.get_icon(ime))
             image.set_pixel_size(48)
             hbox.add(image)
@@ -4113,7 +4113,7 @@ class SetupUI(Gtk.Window): # type: ignore
         if not self._input_methods_listbox_selected_ime_name:
             return
         ime = self._input_methods_listbox_selected_ime_name
-        if not M17N_DB_INFO is None:
+        if M17N_DB_INFO is not None:
             path = M17N_DB_INFO.get_path(ime)
             title = M17N_DB_INFO.get_title(ime)
             description = M17N_DB_INFO.get_description(ime)

--- a/setup/main.py
+++ b/setup/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/setup/pkginstall.py
+++ b/setup/pkginstall.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/setup/test_input_purpose.py
+++ b/setup/test_input_purpose.py
@@ -176,7 +176,7 @@ class InputPurposeTest(Gtk.Window): # type: ignore
         if tree_iter is not None:
             model = widget.get_model()
             self._input_purpose = model[tree_iter][1]
-            if not self._input_purpose in list(itb_util.InputPurpose):
+            if self._input_purpose not in list(itb_util.InputPurpose):
                 LOGGER.info(
                     'self._input_purpose = %s (Unknown)',
                     self._input_purpose)

--- a/setup/test_input_purpose.py
+++ b/setup/test_input_purpose.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/setup/user_transliteration.py
+++ b/setup/user_transliteration.py
@@ -54,30 +54,30 @@ class LangDictTable:
 
     def get_mr_table(self) -> Dict[str, str]:
         table: Dict[str, str] = dict({
-            (u'ā', 'aa'),
-            (u'ṭ', 't'),
-            (u'ḍ', 'd'),
-            (u'ē', 'e'),
-            (u'ĕ', 'ey'),
-            (u'ẖ', 'ha'),
-            (u'ṛ', 'da'),
-            (u'ġ', 'gan'),
-            (u'ī', 'ee'),
-            (u'ḵ', 'k'),
-            (u'ḷ', 'l'),
-            (u'ṁ', '-mm'),
-            (u'ṅ', 'nn'),
-            (u'ṇ', 'na'),
-            (u'', 'a'),
-            (u'ō', 'o'),
-            (u'ṣ', 'sh'),
-            (u'ŏ', 'oy'),
-            (u'ḥ', 'tah'),
-            (u'ś', 'she'),
-            (u'ṟ', 'rr'),
-            (u'ū', 'u'),
-            (u'ñ', 'dnya'),
-            (u'n̄' , 'n')
+            ('ā', 'aa'),
+            ('ṭ', 't'),
+            ('ḍ', 'd'),
+            ('ē', 'e'),
+            ('ĕ', 'ey'),
+            ('ẖ', 'ha'),
+            ('ṛ', 'da'),
+            ('ġ', 'gan'),
+            ('ī', 'ee'),
+            ('ḵ', 'k'),
+            ('ḷ', 'l'),
+            ('ṁ', '-mm'),
+            ('ṅ', 'nn'),
+            ('ṇ', 'na'),
+            ('', 'a'),
+            ('ō', 'o'),
+            ('ṣ', 'sh'),
+            ('ŏ', 'oy'),
+            ('ḥ', 'tah'),
+            ('ś', 'she'),
+            ('ṟ', 'rr'),
+            ('ū', 'u'),
+            ('ñ', 'dnya'),
+            ('n̄' , 'n')
         })
         return table
 
@@ -126,7 +126,7 @@ class LatinConvert:
             except:
                 print("load_dictionary(): loading %(dic)s as %(enc)s encoding failed, giving up." %{
                     'dic': self.hunspell_dict, 'enc': encoding})
-        if dict_buffer[0] == u'\ufeff':
+        if dict_buffer[0] == '\ufeff':
             dict_buffer = dict_buffer[1:]
         return dict_buffer
 
@@ -151,7 +151,7 @@ class LatinConvert:
         for char in word:
             if char in self.lang_table:
                 new_word.append(self.lang_table[char])
-            elif char in[ u'\u0325', u'\u0310',u'\u0304', u'\u0315',u'\u0314']:
+            elif char in[ '\u0325', '\u0310','\u0304', '\u0315','\u0314']:
                 pass
             else:
                 new_word.append(char)

--- a/tests/gtkcases.py
+++ b/tests/gtkcases.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 '''
 Test cases for the graphical Gtk tests.
 

--- a/tests/test_0_gtk.py
+++ b/tests/test_0_gtk.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 #
 # ibus-typing-booster - A completion input method for IBus
 #
@@ -75,13 +74,13 @@ from gtkcases import TestCases # pylint: disable=import-error
 def printflush(sentence: str) -> None:
     try:
         print(sentence, flush=True)
-    except IOError:
+    except OSError:
         pass
 
 def printerr(sentence: str) -> None:
     try:
         print(sentence, flush=True, file=sys.stderr)
-    except IOError:
+    except OSError:
         pass
 
 @unittest.skipUnless(

--- a/tests/test_m17n_translit.py
+++ b/tests/test_m17n_translit.py
@@ -1093,7 +1093,7 @@ class M17nTranslitTestCase(unittest.TestCase):
               'Hiragana or Katakana (not yet implemented)\nSelect Hiragana or Katakana',
               'katakana'),
              ('zen-han', 'Zenkaku or Hankaku (not yet implemented)', 'hankaku')])
-        with open(M17N_CONFIG_FILE, mode='rt', encoding='utf-8') as config_file:
+        with open(M17N_CONFIG_FILE, encoding='utf-8') as config_file:
             config_file_contents = config_file.read()
         self.assertEqual(
             config_file_contents,
@@ -1114,7 +1114,7 @@ class M17nTranslitTestCase(unittest.TestCase):
         trans_bn_national_jatiya.set_variables({'use-automatic-vowel-forming': '1'})
         trans_t_unicode.set_variables({'prompt': 'U+'})
         trans_ja_anthy.set_variables({'input-mode': 'hiragana', 'zen-han': 'zenkaku'})
-        with open(M17N_CONFIG_FILE, mode='rt', encoding='utf-8') as config_file:
+        with open(M17N_CONFIG_FILE, encoding='utf-8') as config_file:
             config_file_contents = config_file.read()
         self.assertEqual(
             config_file_contents,
@@ -1137,7 +1137,7 @@ class M17nTranslitTestCase(unittest.TestCase):
         trans_ja_anthy.set_variables({'input-mode': '', 'zen-han': ''})
         # Setting the *global* default values like this should make the config
         # file empty (except for the comment line at the top):
-        with open(M17N_CONFIG_FILE, mode='rt', encoding='utf-8') as config_file:
+        with open(M17N_CONFIG_FILE, encoding='utf-8') as config_file:
             config_file_contents = config_file.read()
         self.assertEqual(
             config_file_contents,
@@ -1155,7 +1155,7 @@ class M17nTranslitTestCase(unittest.TestCase):
               '1')])
         self.assertEqual(trans.transliterate(['a']), 'ঋ')  # U+098B BENGALI LETTER VOCALIC R
         trans.set_variables({'use-automatic-vowel-forming': '0'})
-        with open(M17N_CONFIG_FILE, mode='rt', encoding='utf-8') as config_file:
+        with open(M17N_CONFIG_FILE, encoding='utf-8') as config_file:
             config_file_contents = config_file.read()
         self.assertEqual(
             config_file_contents,
@@ -1180,7 +1180,7 @@ class M17nTranslitTestCase(unittest.TestCase):
         trans.set_variables({'use-automatic-vowel-forming': ''})
         # Setting the *global* default value like this should make the config
         # file empty (except for the comment line at the top):
-        with open(M17N_CONFIG_FILE, mode='rt', encoding='utf-8') as config_file:
+        with open(M17N_CONFIG_FILE, encoding='utf-8') as config_file:
             config_file_contents = config_file.read()
         self.assertEqual(
             config_file_contents,


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed almost year ago.
Filer all code over `pyup[grade --py38-plus`.