### PR TITLE
Replace shebang from #!/usr/bin/sh to #!/bin/sh

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # Attempt to guess a canonical system name.
 #   Copyright 1992-2023 Free Software Foundation, Inc.
 

--- a/config.sub
+++ b/config.sub
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # Configuration validation subroutine script.
 #   Copyright 1992-2023 Free Software Foundation, Inc.
 

--- a/engine/emoji-picker.in
+++ b/engine/emoji-picker.in
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # vim:set et sts=4 sw=4
 #
 # emoji-picker - An emoji selection tool

--- a/engine/ibus-engine-typing-booster.in
+++ b/engine/ibus-engine-typing-booster.in
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # vim:set et sts=4 sw=4
 #
 # ibus-typing-booster - A completion input method for IBus

--- a/setup/ibus-setup-typing-booster.in
+++ b/setup/ibus-setup-typing-booster.in
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # vim:set noet ts=4:
 #
 #


### PR DESCRIPTION
With distributions that don't have the usr-bin-merge, sh still is under /bin and not /usr/bin.