### PR TITLE
Make emoji picker appdata file translatable

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -10,4 +10,5 @@ engine/main.py
 engine/tabsqlitedb.py
 setup/main.py
 setup/pkginstall.py
+emoji-picker.appdata.xml
 typing-booster.appdata.xml


### PR DESCRIPTION
I am not sure, why it's missing from the POTFILES.in file. Let's add it there.