### PR TITLE
Fix summary for asciidigits

### DIFF
--- a/org.freedesktop.ibus.engine.typing-booster.gschema.xml
+++ b/org.freedesktop.ibus.engine.typing-booster.gschema.xml
@@ -337,7 +337,7 @@
     </key>
     <key name="asciidigits" type="b">
       <default>false</default>
-      <summary>Disable in terminals</summary>
+      <summary>Convert language specific digits to ASCII digits</summary>
       <description>
         Some input methods produce language specific digits by
         default. If one never wants to use such language specific


### PR DESCRIPTION
Copied from
https://github.com/mike-fabian/ibus-typing-booster/blob/2b3f2e8040a9e4a70e0535f884bdb49913e6d66a/setup/main.py#L789