### PR TITLE
Increase pygame.mixer's buffer size

### DIFF
--- a/engine/itb_sound.py
+++ b/engine/itb_sound.py
@@ -132,7 +132,12 @@ class SoundObject:
         if not IMPORT_PYGAME_MIXER_SUCCESSFUL:
             return ''
         try:
-            pygame.mixer.init()
+            # pygame defaults to a low latency (small buffer) that is more
+            # appropriate for foreground games than background processes. Use a
+            # larger than default buffer to prevent audio issues in other
+            # processes when the system is under load:
+            # https://github.com/mike-fabian/ibus-typing-booster/issues/681
+            pygame.mixer.init(buffer=4096)
             if pygame.mixer.get_init():
                 pygame.mixer.music.load(self._path_to_sound_file)
                 return 'pygame'


### PR DESCRIPTION
I wasn't able to reproduce the audible popping sounds from #681 for some reason. Maybe I had different apps running that interacted with pipewire different? However, if I ran this to load the CPU:

```
for i in {1..12}; do cat < /dev/urandom > /dev/null & done
```

I was able to reproduce these wireplumber log lines with the default `pygame.mixer.init()` but not with `pygame.mixer.init(buffer=4096)`:

```
spa.audioconvert: 0x55e3890b13b0: (0 suppressed) out of buffers on port 0 2
```

Before, the node.latency in pipewire was 128/44100, or 3ms. With this change, it's 1166/44100 or 26ms. I doubt 26ms will be noticible to users?

Fixes #681